### PR TITLE
Fix bug with spacing

### DIFF
--- a/AsciiBarGraph.cs
+++ b/AsciiBarGraph.cs
@@ -52,7 +52,7 @@ namespace atlas
             {
                 sb.Append("     ");
                 foreach (var label in lables)
-                    sb.Append(label.Length > i ? $"  {label[i]}  " : "    ");
+                    sb.Append(label.Length > i ? $"  {label[i]}  " : "     ");
                 sb.AppendLine();
             }
 


### PR DESCRIPTION
This fixed #3 

You were only adding 4 spaces instead of 5 space characters per column if we are beyond the length of the label